### PR TITLE
it doesn't work with quotes

### DIFF
--- a/versioning-continuous-delivery/docker-compose.yml
+++ b/versioning-continuous-delivery/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     image: phauer/versioning-continuous-delivery:latest
     network_mode: "host"
     ports:
-      - "8080:8080"
+      - 8080:8080


### PR DESCRIPTION
for docker version
-------------------
Client:
 Version:      17.09.0-ce
 API version:  1.32
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:40:09 2017
 OS/Arch:      darwin/amd64

Server:
 Version:      17.09.0-ce
 API version:  1.32 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:45:38 2017
 OS/Arch:      linux/amd64
 Experimental: true

for docker-compose version
-----------------------------
docker-compose version 1.16.1, build 6d1ac21